### PR TITLE
Implement command handling and tracking required for listing chests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Maven build artifacts
+target/
+
+# IDE files
+.vscode/
+.idea/
+*.iml
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Java compiled files
+*.class
+
+# Log files
+*.log
+
+# Package Files
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.pau.plugins</groupId>
     <artifactId>deathchest</artifactId>
-    <version>1.3</version>
+    <version>1.5</version>
     <packaging>jar</packaging>
 
     <name>DeathChest</name>

--- a/src/main/java/me/pau/plugins/deathchest/DeathChest.java
+++ b/src/main/java/me/pau/plugins/deathchest/DeathChest.java
@@ -3,6 +3,17 @@ package me.pau.plugins.deathchest;
 import me.pau.plugins.deathchest.handlers.*;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.Inventory;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 public class DeathChest extends JavaPlugin {
     public static DeathChest instance;
 
@@ -22,6 +33,19 @@ public class DeathChest extends JavaPlugin {
     Interaction interaction;
     Chests chests;
 
+    // Track chest creation times and owners
+    private final Map<Block, ChestMeta> chestMetaMap = new HashMap<>();
+
+    public static class ChestMeta {
+        public final UUID owner;
+        public final Instant created;
+
+        public ChestMeta(UUID owner, Instant created) {
+            this.owner = owner;
+            this.created = created;
+        }
+    }
+
     @Override
     public void onEnable() {
         instance = this;
@@ -36,17 +60,95 @@ public class DeathChest extends JavaPlugin {
 
         nameVisible = this.getConfig().getBoolean("chest_customization.name_on_chest", true);
 
-        // Anything to do with integrations such as variables checking if a plugin is enabled
+        // Anything to do with integrations such as variables checking if a plugin is
+        // enabled
         isExcellentEnchantsEnabled = getServer().getPluginManager().isPluginEnabled("ExcellentEnchants");
 
         // Main class summoning
         chests = new Chests(instance);
         chests.load();
+
+        // Register all loaded chests as tracked (owner/time unknown)
+        for (Block block : chests.getAllBlocks()) {
+            if (!chestMetaMap.containsKey(block)) {
+                chestMetaMap.put(block, new ChestMeta(null, null));
+            }
+        }
+
+        // If there are any chests loaded onEnable, log the count
+        if (!chests.getAllBlocks().isEmpty()) {
+            infoPrint("There are " + chests.getAllBlocks().size() + " death chests loaded in the world.");
+        }
+
         death = new Death(instance, chests);
-
         interaction = new Interaction(instance, chests);
-
         chests.restoreInWorld();
+
+        // Register command
+        getCommand("deathchest").setExecutor(this);
+    }
+
+    // Called by Death handler when a chest is created
+    public void registerDeathChest(Block block, UUID owner) {
+        chestMetaMap.put(block, new ChestMeta(owner, Instant.now()));
+    }
+
+    // Called by Death handler when a chest is removed
+    public void unregisterDeathChest(Block block) {
+        chestMetaMap.remove(block);
+    }
+
+    // Command handler
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("[SimpleDeathChest] Only players can use this command.");
+            return true;
+        }
+        Player player = (Player) sender;
+        if (args.length == 1 && args[0].equalsIgnoreCase("list")) {
+            // List all death chests for this player, and also show unknown owner/time
+            int i = 1;
+            player.sendMessage("[SimpleDeathChest] Your death chests are at:");
+            Instant now = Instant.now();
+            for (Map.Entry<Block, ChestMeta> entry : chestMetaMap.entrySet()) {
+                Block block = entry.getKey();
+                ChestMeta meta = entry.getValue();
+                if (meta.owner == null || meta.created == null) {
+                    player.sendMessage(String.format("[SimpleDeathChest] %d. X:%d, Y:%d, Z:%d (unknown owner/time)",
+                        i++, block.getX(), block.getY(), block.getZ()));
+                } else if (meta.owner.equals(player.getUniqueId())) {
+                    Duration duration = Duration.between(meta.created, now);
+                    String timeAgo = formatDuration(duration);
+                    player.sendMessage(String.format("[SimpleDeathChest] %d. X:%d, Y:%d, Z:%d (%s ago)",
+                        i++, block.getX(), block.getY(), block.getZ(), timeAgo));
+                }
+            }
+            if (i == 1) {
+                player.sendMessage("[SimpleDeathChest] You have no active death chests.");
+            }
+            return true;
+        }
+        player.sendMessage("[SimpleDeathChest] Usage: /deathchest list");
+        return true;
+    }
+
+    // Helper to format duration as '4 minutes', '1 day and 25 minutes', etc.
+    private static String formatDuration(Duration duration) {
+        long days = duration.toDays();
+        long hours = duration.toHours() % 24;
+        long minutes = duration.toMinutes() % 60;
+        if (days > 0) {
+            return String.format("%d day%s and %d minute%s",
+                    days, days == 1 ? "" : "s",
+                    minutes, minutes == 1 ? "" : "s");
+        } else if (hours > 0) {
+            return String.format("%d hour%s and %d minute%s",
+                    hours, hours == 1 ? "" : "s",
+                    minutes, minutes == 1 ? "" : "s");
+        } else {
+            return String.format("%d minute%s",
+                    minutes, minutes == 1 ? "" : "s");
+        }
     }
 
     @Override

--- a/src/main/java/me/pau/plugins/deathchest/handlers/Chests.java
+++ b/src/main/java/me/pau/plugins/deathchest/handlers/Chests.java
@@ -1,3 +1,4 @@
+
 package me.pau.plugins.deathchest.handlers;
 
 import me.pau.plugins.deathchest.DeathChest;
@@ -19,15 +20,23 @@ import static me.pau.plugins.deathchest.DeathChest.infoPrint;
 import static me.pau.plugins.deathchest.DeathChest.warnPrint;
 
 public class Chests {
+
+    // Utility to get all blocks with death chests
+    public Set<Block> getAllBlocks() {
+        return deathChests.keySet();
+    }
+
     private final JavaPlugin plugin;
     private final HashMap<Block, Inventory> deathChests = new HashMap<>();
+
     public Chests(DeathChest plugin) {
         this.plugin = plugin;
     }
 
     /**
-     * @param block the chest-block as a key for the inventory
-     * @param inventory the inventory where the player's items are in assigned to the chest
+     * @param block     the chest-block as a key for the inventory
+     * @param inventory the inventory where the player's items are in assigned to
+     *                  the chest
      */
     public void put(Block block, Inventory inventory) {
         deathChests.put(block, inventory);
@@ -35,7 +44,8 @@ public class Chests {
 
     /**
      * @param key block for where the inventory should be in
-     * @return value of the block (key) on the hash map of block, inventory where deathchest information is stored
+     * @return value of the block (key) on the hash map of block, inventory where
+     *         deathchest information is stored
      */
     public Inventory get(Block key) {
         return deathChests.get(key);
@@ -54,13 +64,13 @@ public class Chests {
         return null;
     }
 
-//    /**
-//     * @param block block-key for which inventory will be accessed
-//     * @return array of all items on the inventory from the block
-//     */
-//    public ItemStack[] getItems(Block block) {
-//        return deathChests.get(block).getContents();
-//    }
+    // /**
+    // * @param block block-key for which inventory will be accessed
+    // * @return array of all items on the inventory from the block
+    // */
+    // public ItemStack[] getItems(Block block) {
+    // return deathChests.get(block).getContents();
+    // }
 
     /**
      * @param key block that will be checked if part of the hash map
@@ -71,7 +81,8 @@ public class Chests {
     }
 
     /**
-     * @param value inventory value that will be checked if it is part of the hash map
+     * @param value inventory value that will be checked if it is part of the hash
+     *              map
      * @return whether the inventory is a value of the hash map
      */
     public boolean containsValue(Inventory value) {
@@ -98,12 +109,13 @@ public class Chests {
     }
 
     /**
-     * Saves current state of the hash map containing chests and inventories to a YamlConfiguration
+     * Saves current state of the hash map containing chests and inventories to a
+     * YamlConfiguration
      */
     public void save() {
         File file = new File(plugin.getDataFolder(), "deathChests.yml");
         FileConfiguration emptyConfig = new YamlConfiguration();
-        
+
         try {
             emptyConfig.save(file);
         } catch (IOException e) {
@@ -128,7 +140,8 @@ public class Chests {
     }
 
     /**
-     * Loads the new state of the hash map containing chests and inventories from the saved YamlConfiguration
+     * Loads the new state of the hash map containing chests and inventories from
+     * the saved YamlConfiguration
      */
     public void load() {
         File file = new File(plugin.getDataFolder(), "deathChests.yml");

--- a/src/main/java/me/pau/plugins/deathchest/handlers/Death.java
+++ b/src/main/java/me/pau/plugins/deathchest/handlers/Death.java
@@ -40,27 +40,32 @@ public class Death implements Listener {
         Location chestLocation;
 
         List<ItemStack> playerDrops = event.getDrops();
-        if (playerDrops.isEmpty()) { return; }
+        if (playerDrops.isEmpty()) {
+            return;
+        }
 
         int chestInventorySize = Math.ceilDiv(playerDrops.size(), 9) * 9;
 
-        Inventory customInventory = (nameVisible) ?
-                Bukkit.createInventory(null, chestInventorySize, Component.text(player.getName())) :
-                Bukkit.createInventory(null, chestInventorySize);
+        Inventory customInventory = (nameVisible)
+                ? Bukkit.createInventory(null, chestInventorySize, Component.text(player.getName()))
+                : Bukkit.createInventory(null, chestInventorySize);
         chestLocation = new Location(
                 player.getWorld(),
                 player.getX(),
-                (player.getY() <= player.getWorld().getMinHeight()) ?
-                        (player.getWorld().getMinHeight() + 1) :
-                        player.getY(),
-                player.getZ()
-        );
+                (player.getY() <= player.getWorld().getMinHeight()) ? (player.getWorld().getMinHeight() + 1)
+                        : player.getY(),
+                player.getZ());
 
         Block block = chestLocation.getBlock();
-        if (block.getType() == Material.CHEST) { block = block.getRelative(BlockFace.UP); }
+        if (block.getType() == Material.CHEST) {
+            block = block.getRelative(BlockFace.UP);
+        }
 
         block.setType(Material.CHEST);
         block.getState().update(true);
+
+        // Register chest with owner and creation time
+        instance.registerDeathChest(block, player.getUniqueId());
 
         if (instance.isExcellentEnchantsEnabled()) {
             Enchantment soulbound = Enchantment.getByKey(NamespacedKey.fromString("minecraft:soulbound"));

--- a/src/main/java/me/pau/plugins/deathchest/handlers/Interaction.java
+++ b/src/main/java/me/pau/plugins/deathchest/handlers/Interaction.java
@@ -1,4 +1,5 @@
 package me.pau.plugins.deathchest.handlers;
+
 import me.pau.plugins.deathchest.DeathChest;
 
 import org.bukkit.Bukkit;
@@ -33,7 +34,9 @@ public class Interaction implements Listener {
     @EventHandler
     public void onBlockBreak(BlockBreakEvent event) {
         Block brokenBlock = event.getBlock();
-        if (!deathChests.containsKey(brokenBlock)) { return; }
+        if (!deathChests.containsKey(brokenBlock)) {
+            return;
+        }
 
         if (playerBreakable) {
             event.setDropItems(false);
@@ -44,16 +47,24 @@ public class Interaction implements Listener {
             return;
         }
 
-        if (!deathChests.get(brokenBlock).isEmpty()) { event.setCancelled(true);}
+        if (!deathChests.get(brokenBlock).isEmpty()) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler
     public void onChestOpen(PlayerInteractEvent event) {
-        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) { return; }
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
         Block clickedBlock = event.getClickedBlock();
 
-        if (clickedBlock == null) { return; }
-        if (clickedBlock.getType() != Material.CHEST) { return; }
+        if (clickedBlock == null) {
+            return;
+        }
+        if (clickedBlock.getType() != Material.CHEST) {
+            return;
+        }
 
         if (deathChests.containsKey(clickedBlock)) {
             Player player = event.getPlayer();
@@ -64,21 +75,25 @@ public class Interaction implements Listener {
 
     @EventHandler
     public void onChestClose(InventoryCloseEvent event) {
-        if (!deathChests.containsValue(event.getInventory())) { return; }
-        if (!event.getInventory().isEmpty()) { return; }
+        if (!deathChests.containsValue(event.getInventory())) {
+            return;
+        }
+        if (!event.getInventory().isEmpty()) {
+            return;
+        }
 
         Block block = deathChests.get(event.getInventory());
         deathChests.remove(block);
-
+        me.pau.plugins.deathchest.DeathChest.instance.unregisterDeathChest(block);
         block.setType(Material.AIR);
     }
 
     @EventHandler
     public void onBlockExplode(BlockExplodeEvent event) {
-        if (!explosionProof) { return; }
-        event.blockList().removeIf(block ->
-                block.getType() == Material.CHEST && deathChests.containsKey(block)
-        );
+        if (!explosionProof) {
+            return;
+        }
+        event.blockList().removeIf(block -> block.getType() == Material.CHEST && deathChests.containsKey(block));
     }
 
     @EventHandler
@@ -86,7 +101,9 @@ public class Interaction implements Listener {
         Optional<Block> chestOptional = event.blockList().stream()
                 .filter(block -> block.getType() == Material.CHEST && deathChests.containsKey(block))
                 .findFirst();
-        if (chestOptional.isEmpty()) { return; }
+        if (chestOptional.isEmpty()) {
+            return;
+        }
 
         Block chest = chestOptional.get();
         event.blockList().remove(chest);
@@ -101,12 +118,13 @@ public class Interaction implements Listener {
     }
 
     /**
-     * @param items array of items to be dropped
+     * @param items    array of items to be dropped
      * @param location where items will be dropped
      */
     public void dropItems(ItemStack[] items, Location location) {
         World world = location.getWorld();
-        if (world == null) return;
+        if (world == null)
+            return;
 
         for (ItemStack item : items) {
             if (item != null && item.getAmount() > 0) {
@@ -116,4 +134,3 @@ public class Interaction implements Listener {
     }
 
 }
-

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: DeathChest
-version: '1.4.1'
+version: '1.5.1'
 main: me.pau.plugins.deathchest.DeathChest
 api-version: '1.13'
 author: defNotPau

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ softdepend:
  - ExcellentEnchants
 
 commands:
-	deathchest:
-		description: Main command for DeathChest plugin
-		usage: /<command> [list]
-		aliases: [dc]
+  deathchest:
+    description: Main command for DeathChest plugin
+    usage: /<command> [list]
+    aliases: [dc]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,3 +6,9 @@ author: defNotPau
 description: Simple, hopefully efficient and reliable Death Chest plugin so items won't despawn
 softdepend:
  - ExcellentEnchants
+
+commands:
+	deathchest:
+		description: Main command for DeathChest plugin
+		usage: /<command> [list]
+		aliases: [dc]


### PR DESCRIPTION
This is an implementation for the suggested issue #4 
I've tested it while the server is running and upon reload.

## Changes

- onEnable - read from the saved death chests to populate tracking
- add `/deathchest list` or `/dc list` command to list the players (and unknown players) death chests
  - I didn't want to modify the save file format, so player metadata is lost after restarting the server. That could be a future enhancement.
- Formatted the .java classes

## Screenshots

<img width="1039" height="344" alt="image" src="https://github.com/user-attachments/assets/389812ce-4e8b-424c-b60b-e75c0de356be" />

<img width="1005" height="119" alt="image" src="https://github.com/user-attachments/assets/99da79c9-dbee-491f-8c5a-3a9a29f04482" />

<img width="1984" height="896" alt="image" src="https://github.com/user-attachments/assets/03b0acd7-861c-44fe-aa18-fe60c6c311e8" />
