### PR TITLE
Fix the noDeathchests translate call

### DIFF
--- a/src/main/java/me/pau/plugins/deathchest/commands/ChestList.java
+++ b/src/main/java/me/pau/plugins/deathchest/commands/ChestList.java
@@ -55,7 +55,7 @@ public class ChestList implements CommandExecutor {
                 }
             }
             if (i == 1) {
-                player.sendMessage(String.format("[SimpleDeathChest] %s", lang.translate("list.noDeathchest")));
+                player.sendMessage(String.format("[SimpleDeathChest] %s", lang.translate("list.noDeathchests")));
             }
             return true;
         }


### PR DESCRIPTION
The plugin wasn't working for me. I traced it down to this call (thanks for the assist Gemini). I was able to temporarily fix it by adding a list.noDeathchest line to my en.yml, but this is probably the correct fix.